### PR TITLE
Change latest released version to 0.7.1

### DIFF
--- a/app/Library/Properties/AssemblyInfo.cs
+++ b/app/Library/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.0.0")]
-[assembly: AssemblyFileVersion("0.7.0.0")]
+[assembly: AssemblyVersion("0.7.1.0")]
+[assembly: AssemblyFileVersion("0.7.1.0")]

--- a/app/Please/Please.nuspec
+++ b/app/Please/Please.nuspec
@@ -13,9 +13,5 @@
     <summary>Please is a set of commands useful for maintaining software projects.</summary>
     <releaseNotes>See the README for an overview of functionality.</releaseNotes>
     <language>en-US</language>
-    <dependencies>
-      <dependency id="Castle.Core" version="2.5.2" />
-      <dependency id="simpler" version="2.3.0" />
-    </dependencies>
   </metadata>
 </package>

--- a/app/Please/Please.nuspec
+++ b/app/Please/Please.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Please</id>
-    <version>0.7.0</version>
+    <version>0.7.1</version>
     <title>Please</title>
     <authors>Resource Data, Inc.</authors>
     <owners>Resource Data, Inc</owners>

--- a/app/Please/Properties/AssemblyInfo.cs
+++ b/app/Please/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.0.0")]
-[assembly: AssemblyFileVersion("0.7.0.0")]
+[assembly: AssemblyVersion("0.7.1.0")]
+[assembly: AssemblyFileVersion("0.7.1.0")]

--- a/config.json
+++ b/config.json
@@ -21,8 +21,7 @@
     "nuspec": "app/Please/Please.nuspec",
     "nupkgPattern": "Please.?.?.?.nupkg",
     "tools": [
-      "app/Please/bin/Release/please.exe",
-      "app/Please/bin/Release/Library.dll"
+      "app/Please/bin/Release/please.exe"
     ],
     "output": {
       "prep": "output/release/prep",


### PR DESCRIPTION
Please was pushed to NuGet as version 0.7.0 but as soon as I tried to install version 0.7.0 I received an error because Please is setup as a tool in its NuGet package and therefore can't reference dependencies that target projects (Simpler and Castle.Core). The dependencies aren't needed anyway since ILMerge was used to combine everything into a single `please.exe`. The fix required a bump to 0.7.1 and another push to NuGet.

Note: There have been several PRs merged to master since 0.7.0 so the code that was used to build 0.7.0 and 0.7.1 came from [this commit](https://github.com/ResourceDataInc/please/commit/a25ec6dd41fb7d6590c573f73ee54935551c4288). 

This PR is related to #8.

Todo
- [ ] Change the CI scripts back to using ILMerge for releases post-0.7.1 (one of the PRs that has been merged to `master` removed it)
